### PR TITLE
Expose `Comparison` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { and } from './and';
-export { comparison, comparison as cmp } from './comparison';
+export { comparison, comparison as cmp, Comparison } from './comparison';
 export { eq } from './eq';
 export { ge } from './ge';
 export { gt } from './gt';

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { and, cmp, comparison, eq, ge, gt, inList, le, lt, ne, or, outList } from '../src';
+import { Comparison, and, cmp, comparison, eq, ge, gt, inList, le, lt, ne, or, outList } from '../src';
 
 describe('Functional tests', () => {
   it('should export public functions', () => {
@@ -15,6 +15,7 @@ describe('Functional tests', () => {
     expect(typeof ne).toBe('function');
     expect(typeof or).toBe('function');
     expect(typeof outList).toBe('function');
+    expect(typeof Comparison).toBe('function');
   });
 
   it('should build the query', () => {


### PR DESCRIPTION
`Comparison` is mentioned in the `Readme` as an argument to some operators but is not exposed to the developer to create instances of the `Comparison` class.