### PR TITLE
Custom List operations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -89,7 +89,20 @@
     "guard-for-in": "error",
     "id-blacklist": "warn",
     "id-match": "warn",
+    "import/newline-after-import": "error",
     "import/no-default-export": "error",
+    "import/order": [
+      "error",
+      {
+        "alphabetize": {
+          "order": "desc",
+          "orderImportKind": "asc",
+          "caseInsensitive": true
+        },
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "newlines-between": "always"
+      }
+    ],
     "jsdoc/check-alignment": "error",
     "jsdoc/check-indentation": "error",
     "jsdoc/tag-lines": [

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ New operators can be easily created as follows:
 import { Operation } from 'rsql-builder';
 
 export function like(value) {
-  return new Operation(value, '=like=');
+  return new Operation(escapeValue(value), '=like=');
 }
 ```
 
@@ -227,7 +227,7 @@ import { like } from '../my-rsql-operators/like';
 const op = like('John Travolta'); // '=like="John Travolta"'
 ```
 
-If the value can contain special characters, `escapeValue` function can be used to escape them:
+It is recommended to use `escapeValue` function that handles special characters, however, you can omit it if you don't need it.
 
 ```js
 new Operation(escapeValue(value), '=like=');

--- a/README.md
+++ b/README.md
@@ -232,3 +232,11 @@ If the value can contain special characters, `escapeValue` function can be used 
 ```js
 new Operation(escapeValue(value), '=like=');
 ```
+
+A custom list operator could look like this:
+
+```js
+function customListOperator(value: Argument[]): Operation {
+  return new Operation(`(${escapeValue(value)})`, '=customListOperator=');
+}
+```

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ new Operation(escapeValue(value), '=like=');
 
 A custom list operator could look like this:
 
-```js
+```typescript
 function customListOperator(value: Argument[]): Operation {
   return new Operation(`(${escapeValue(value)})`, '=customListOperator=');
 }

--- a/README.md
+++ b/README.md
@@ -226,3 +226,9 @@ import { like } from '../my-rsql-operators/like';
 
 const op = like('John Travolta'); // '=like="John Travolta"'
 ```
+
+If the value can contain special characters, `escapeValue` function can be used to escape them:
+
+```js
+new Operation(escapeValue(value), '=like=');
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rm -rf ./dist && npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc -p . && echo '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
     "build:esm": "tsc --module ES6 --outDir dist/esm -p .",
-    "lint": "eslint README.md src tests",
+    "lint": "eslint src tests",
     "lint:fix": "npm run lint -- --fix",
     "precommit": "lint-staged",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rm -rf ./dist && npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc -p . && echo '{\"type\":\"commonjs\"}' > ./dist/cjs/package.json",
     "build:esm": "tsc --module ES6 --outDir dist/esm -p .",
-    "lint": "eslint src tests",
+    "lint": "eslint README.md src tests",
     "lint:fix": "npm run lint -- --fix",
     "precommit": "lint-staged",
     "prepare": "husky install",

--- a/src/eq.ts
+++ b/src/eq.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create equal operation

--- a/src/eq.ts
+++ b/src/eq.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function eq(argument: Argument): Operation {
-  return new Operation(argument, Operators.EQUAL);
+  return new Operation(escapeValue(argument), Operators.EQUAL);
 }

--- a/src/escape-value.ts
+++ b/src/escape-value.ts
@@ -1,41 +1,16 @@
-import { Argument } from './operation.js';
-
 const CHARS_TO_ESCAPE = /["'();,=!~<>\s]/;
 
-export class EscapedValue {
-  private val: string;
+export function escapeValue(value: unknown): string {
+  let valueString: string;
 
-  constructor(val: string) {
-    this.val = val;
-  }
-
-  toString(): string {
-    return this.val;
-  }
-}
-
-/**
- * Escape string value
- *
- * @param value Value to escape
- * @returns EscapedValue instance
- */
-export function escapeValue(value: Argument): EscapedValue {
-  if (value instanceof EscapedValue) {
-    return value;
-  }
-
-  let val: string;
-
-  if (typeof value !== 'string') {
-    val = value.toString();
+  if (Array.isArray(value)) {
+    return `${value.map(escapeValue)}`;
   } else {
-    val = value;
+    valueString = value.toString();
+  }
+  if (CHARS_TO_ESCAPE.test(valueString) || valueString.length === 0) {
+    valueString = `"${valueString.replace(/"/g, '\\"')}"`;
   }
 
-  if (CHARS_TO_ESCAPE.test(val) || val.length === 0) {
-    return new EscapedValue(`"${val.replace(/"/g, '\\"')}"`);
-  } else {
-    return new EscapedValue(val);
-  }
+  return valueString;
 }

--- a/src/escape-value.ts
+++ b/src/escape-value.ts
@@ -1,13 +1,12 @@
 const CHARS_TO_ESCAPE = /["'();,=!~<>\s]/;
 
 export function escapeValue(value: unknown): string {
-  let valueString: string;
-
   if (Array.isArray(value)) {
     return `${value.map(escapeValue)}`;
-  } else {
-    valueString = value.toString();
   }
+
+  let valueString = value.toString();
+
   if (CHARS_TO_ESCAPE.test(valueString) || valueString.length === 0) {
     valueString = `"${valueString.replace(/"/g, '\\"')}"`;
   }

--- a/src/ge.ts
+++ b/src/ge.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create greater-or-equal operation

--- a/src/ge.ts
+++ b/src/ge.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function ge(argument: Argument): Operation {
-  return new Operation(argument, Operators.GREATER_OR_EQUAL);
+  return new Operation(escapeValue(argument), Operators.GREATER_OR_EQUAL);
 }

--- a/src/gt.ts
+++ b/src/gt.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create greater-than operation

--- a/src/gt.ts
+++ b/src/gt.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function gt(argument: Argument): Operation {
-  return new Operation(argument, Operators.GREATER_THAN);
+  return new Operation(escapeValue(argument), Operators.GREATER_THAN);
 }

--- a/src/in-list.ts
+++ b/src/in-list.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create in-list operation

--- a/src/in-list.ts
+++ b/src/in-list.ts
@@ -1,4 +1,4 @@
-import { escapeValue, EscapedValue } from './escape-value.js';
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -18,5 +18,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function inList(...args: Argument[]): Operation {
-  return new Operation(new EscapedValue(`(${args.map(escapeValue).join(',')})`), Operators.IN);
+  return new Operation(`(${args.map(escapeValue).join(',')})`, Operators.IN);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export { ne } from './ne.js';
 export { or } from './or.js';
 export { outList } from './out-list.js';
 export { Operation, Operators } from './operation.js';
+export { escapeValue } from './escape-value.js';

--- a/src/le.ts
+++ b/src/le.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function le(argument: Argument): Operation {
-  return new Operation(argument, Operators.LESS_OR_EQUAL);
+  return new Operation(escapeValue(argument), Operators.LESS_OR_EQUAL);
 }

--- a/src/le.ts
+++ b/src/le.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create less-or-equal operation

--- a/src/lt.ts
+++ b/src/lt.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create less-than operation

--- a/src/lt.ts
+++ b/src/lt.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function lt(argument: Argument): Operation {
-  return new Operation(argument, Operators.LESS_THAN);
+  return new Operation(escapeValue(argument), Operators.LESS_THAN);
 }

--- a/src/ne.ts
+++ b/src/ne.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create not-equal operation

--- a/src/ne.ts
+++ b/src/ne.ts
@@ -1,3 +1,4 @@
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -15,5 +16,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function ne(argument: Argument): Operation {
-  return new Operation(argument, Operators.NOT_EQUAL);
+  return new Operation(escapeValue(argument), Operators.NOT_EQUAL);
 }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,5 +1,3 @@
-import { escapeValue, EscapedValue } from './escape-value.js';
-
 /**
  * Operators signs
  *
@@ -15,12 +13,12 @@ export enum Operators {
   OUT = '=out='
 }
 
-export type Argument = number | string | boolean | EscapedValue;
+export type Argument = number | string | boolean;
 
 export class Operation {
   constructor(private args: Argument, private operator: Operators | string = Operators.EQUAL) {}
 
   toString(): string {
-    return `${this.operator}${escapeValue(this.args).toString()}`;
+    return `${this.operator}${this.args.toString()}`;
   }
 }

--- a/src/out-list.ts
+++ b/src/out-list.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
+import { escapeValue } from './escape-value.js';
 
 /**
  * Create out-list operation

--- a/src/out-list.ts
+++ b/src/out-list.ts
@@ -1,4 +1,4 @@
-import { escapeValue, EscapedValue } from './escape-value.js';
+import { escapeValue } from './escape-value.js';
 import { Argument, Operation, Operators } from './operation.js';
 
 /**
@@ -18,5 +18,5 @@ import { Argument, Operation, Operators } from './operation.js';
  *
  */
 export function outList(...args: Argument[]): Operation {
-  return new Operation(new EscapedValue(`(${args.map(escapeValue).join(',')})`), Operators.OUT);
+  return new Operation(`(${args.map(escapeValue).join(',')})`, Operators.OUT);
 }

--- a/tests/comparison.spec.ts
+++ b/tests/comparison.spec.ts
@@ -1,5 +1,5 @@
-import { cmp, Operation, Operators } from '../src';
 import { escapeValue } from '../src/escape-value';
+import { cmp, Operation, Operators } from '../src';
 
 describe('cmp()', () => {
   it('should return the correct comparison', () => {

--- a/tests/comparison.spec.ts
+++ b/tests/comparison.spec.ts
@@ -1,13 +1,20 @@
 import { cmp, Operation, Operators } from '../src';
+import { escapeValue } from '../src/escape-value';
 
 describe('cmp()', () => {
   it('should return the correct comparison', () => {
     expect(cmp('field', new Operation(200, Operators.EQUAL)).toString()).toBe('field==200');
     expect(cmp('field', new Operation('string', Operators.GREATER_OR_EQUAL)).toString()).toBe('field>=string');
     expect(cmp('field', new Operation('string with spaces', Operators.LESS_OR_EQUAL)).toString()).toBe(
+      'field<=string with spaces'
+    );
+    expect(cmp('field', new Operation(escapeValue('string with spaces'), Operators.LESS_OR_EQUAL)).toString()).toBe(
       'field<="string with spaces"'
     );
     expect(cmp('field', new Operation('"quoted" string', Operators.LESS_THAN)).toString()).toBe(
+      'field<"quoted" string'
+    );
+    expect(cmp('field', new Operation(escapeValue('"quoted" string'), Operators.LESS_THAN)).toString()).toBe(
       'field<"\\"quoted\\" string"'
     );
   });

--- a/tests/custom-operator.spec.ts
+++ b/tests/custom-operator.spec.ts
@@ -5,6 +5,10 @@ function customOperator(value: Argument): Operation {
   return new Operation(escapeValue(value), '=custom=');
 }
 
+function customListOperator(value: Argument[]): Operation {
+  return new Operation(`(${escapeValue(value)})`, '=customListOperator=');
+}
+
 describe('custom operator', () => {
   it('should return custom-expression string when a number is provided', () => {
     expect(customOperator(100).toString()).toBe('=custom=100');
@@ -20,5 +24,11 @@ describe('custom operator', () => {
 
   it('should return custom-expression string when a string with quotes is provided', () => {
     expect(customOperator('"quoted" string').toString()).toBe('=custom="\\"quoted\\" string"');
+  });
+});
+
+describe('custom list operator', () => {
+  it('should return custom-expression string when a number is provided', () => {
+    expect(customListOperator(['first', 'second']).toString()).toBe('=customListOperator=(first,second)');
   });
 });

--- a/tests/custom-operator.spec.ts
+++ b/tests/custom-operator.spec.ts
@@ -1,7 +1,8 @@
+import { escapeValue } from '../src/escape-value';
 import { Argument, Operation } from '../src/operation';
 
 function customOperator(value: Argument): Operation {
-  return new Operation(value, '=custom=');
+  return new Operation(escapeValue(value), '=custom=');
 }
 
 describe('custom operator', () => {

--- a/tests/custom-operator.spec.ts
+++ b/tests/custom-operator.spec.ts
@@ -1,5 +1,5 @@
-import { escapeValue } from '../src/escape-value';
 import { Argument, Operation } from '../src/operation';
+import { escapeValue } from '../src/escape-value';
 
 function customOperator(value: Argument): Operation {
   return new Operation(escapeValue(value), '=custom=');

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { Comparison, and, cmp, comparison, eq, ge, gt, inList, le, lt, ne, or, outList } from '../src';
+import { Comparison, and, cmp, comparison, eq, escapeValue, ge, gt, inList, le, lt, ne, or, outList } from '../src';
 
 describe('Functional tests', () => {
   it('should export public functions', () => {
@@ -16,6 +16,7 @@ describe('Functional tests', () => {
     expect(typeof or).toBe('function');
     expect(typeof outList).toBe('function');
     expect(typeof Comparison).toBe('function');
+    expect(typeof escapeValue).toBe('function');
   });
 
   it('should build the query', () => {


### PR DESCRIPTION
The pull request simplifies working with list operators making them similar to non-list operators. On top of that, it provides support for creating custom list operators in the same way as non-list operators can be created.

It also exposes the `escapeValue` function, which handles special characters and arrays.

The resolved issue: #66 