### PR TITLE
Chore: Update actions/setup-node to v6.4.0 and coverallsapp/github-action to v2.3.6

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -16,14 +16,14 @@ jobs:
     name: Test with node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm run lint
       - run: npm run test
       - run: npm run test:smoke
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: node v${{ matrix.node }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publishing coverage report
     steps:
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true


### PR DESCRIPTION
Closes #555

Updates CI workflow action versions:

- `actions/setup-node` from `v6` → `v6.4.0`
- `coverallsapp/github-action` from `master` → `v2.3.6`

### Files changed
- `.github/workflows/npm-test.yml`