### PR TITLE
Fix: NPM publish workflow not triggered when publishing a draft release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   id-token: write  # Required for OIDC


### PR DESCRIPTION
Closes #556

The `npm-publish.yml` workflow was triggered on `release: [created]`, but when a **draft** release is published, GitHub sends a `published` event — not `created`. This meant the workflow never ran for draft releases.

**Fix:** Changed the trigger to `published`, which covers both:
- Publishing a draft release
- Creating a non-draft release directly

### Files changed
- `.github/workflows/npm-publish.yml`