### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RomiC/rsql-builder/security/code-scanning/3](https://github.com/RomiC/rsql-builder/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/npm-test.yml` at the workflow root (right after `on` block, before `jobs`) so all jobs inherit a restricted token scope by default.

Best single fix without changing intended functionality:
- Add:
  - `contents: read` (needed for checkout/read repo)
  - `statuses: write` (Coveralls commonly updates commit status checks)
- Keep job logic unchanged.
- If future failures indicate additional scopes are required (for example checks), add only those explicitly.

File/region to change:
- `.github/workflows/npm-test.yml`
- Insert new root-level `permissions:` block between existing trigger section and `jobs:`.

No imports/dependencies/methods are needed (YAML workflow-only edit).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
