### PR TITLE
Fixing default branch name in npm-test flow

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize]
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rsql-builder [![Coverage Status](https://coveralls.io/repos/github/RomiC/rsql-builder/badge.svg)](https://coveralls.io/github/RomiC/rsql-builder)
+# rsql-builder ![NPM Version](https://img.shields.io/npm/v/rsql-builder) [![Coverage Status](https://coveralls.io/repos/github/RomiC/rsql-builder/badge.svg?branch=main)](https://coveralls.io/github/RomiC/rsql-builder?branch=main)
 
 Here is the simple rsql-query builder utility. It's as minimal as possible but quite powerful at the same time.
 


### PR DESCRIPTION
After renaming the default branch from `master` to `main`, the `npm-test` flow should be updated accordingly.