### PR TITLE
Chore: Remove deprecated husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "precommit": "lint-staged",
-    "prepare": "husky install",
+    "prepare": "husky",
     "prepush": "npm run test && npm run test:smoke",
     "pretest": "npm run build:test",
     "pretest:no-coverage": "npm run build:test",


### PR DESCRIPTION
## Summary

Fixes the `husky - install command is DEPRECATED` warning shown during `npm ci`.

## Changes

- Replace `"prepare": "husky install"` with `"prepare": "husky"` in `package.json`

In husky 9, `husky install` is deprecated — running `husky` without arguments auto-installs the hooks (see [husky docs](https://typicode.github.io/husky/how-to.html)).